### PR TITLE
Breaking change: drop JSON element from Event.

### DIFF
--- a/src/main/kotlin/org/conservationco/asana/extensions/Requests.kt
+++ b/src/main/kotlin/org/conservationco/asana/extensions/Requests.kt
@@ -67,13 +67,13 @@ internal fun Collection<JsonElement>.extractResourceEvents(resourceType: String,
         if (element["type"].asString != resourceType) continue
 
         val action = element["action"].asString
-        if (action in actionsAsJsonNames) {
-            val changeTypeEnum = Action.fromString(action)
-            val resourceBody = element["resource"] as JsonObject
-            val gid = resourceBody["gid"].asString
-            val packaged = Event(gid, changeTypeEnum, element)
-            events.add(packaged)
-        }
+        if (action !in actionsAsJsonNames) continue
+
+        val changeTypeEnum = Action.fromString(action)
+        val resourceBody = element["resource"] as JsonObject
+        val gid = resourceBody["gid"].asString
+        val packaged = Event(gid, changeTypeEnum)
+        events.add(packaged)
     }
     return events
 }

--- a/src/main/kotlin/org/conservationco/asana/extensions/events/Event.kt
+++ b/src/main/kotlin/org/conservationco/asana/extensions/events/Event.kt
@@ -1,7 +1,5 @@
 package org.conservationco.asana.extensions.events
 
-import com.google.gson.JsonElement
-
 /**
  * Encapsulates a single Asana event.
  *
@@ -10,10 +8,8 @@ import com.google.gson.JsonElement
  *
  * @property resourceGid The [com.asana.models.Resource] that this event occurred on.
  * @property type The type of change that occurred.
- * @property eventBody The JSON body containing what changed.
  */
 data class Event(
     val resourceGid: String,
     val type: Action,
-    val eventBody: JsonElement,
 )


### PR DESCRIPTION
This is a tough change to make, but there a few reasons why.

First, the Asana API returns many duplicates for any given event. Since Event is a data class, we'd like to have equivalent hashcodes for equivalent events. However, there's no simple way to accomplish that AND hold the JSON body as a property of Event objects.

Second, the JSON body is marginally useful, and only for change events.